### PR TITLE
Fix dtype handling for Whisper ASR

### DIFF
--- a/src/rl/utils.py
+++ b/src/rl/utils.py
@@ -37,7 +37,6 @@ speechbrain_speaker_model = EncoderClassifier.from_hparams(
 SPEECHBRAIN_TARGET_SR = 16000
 
 # Ensure os is imported for path checking
-import os
 
 # test_spk function removed as it was for manual verification.
 
@@ -115,7 +114,7 @@ def get_asr(audios, sr):
         audios_resampled = audios
 
     for i in range(audios_resampled.size(0)):
-        audio_input_np = audios_resampled[i, :].cpu().numpy()
+        audio_input_np = audios_resampled[i, :].float().cpu().numpy()
 
         # Transcribe audio
         # Adjust beam_size, language, etc. as needed.


### PR DESCRIPTION
## Summary
- ensure audio passed to Whisper is float32
- cleanup unused import

## Testing
- `ruff check src/rl/utils.py`

------
https://chatgpt.com/codex/tasks/task_e_686764ff0890832e91d295d4107f9dc2